### PR TITLE
[Feature] Add disable info logs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ to start it in the console. Each instance gets its own
 console tab based on the script name, so running multiple 
 scripts at the same time is no problem.
 
+## Configuration
+
+{
+  ...
+  "npm-scripts.showStartNotification": false   // Disables dropdown notification
+  ...
+}
 
 ## Development
 
@@ -22,3 +29,7 @@ scripts at the same time is no problem.
 - `npm install`
 - `npm run compile`
 - `F5` to start debugging
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-npm-scripts",
     "displayName": "NPM-Scripts",
     "description": "View and run NPM scripts in the sidebar.",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "publisher": "traBpUkciP",
     "engines": {
         "vscode": "^1.13.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,18 @@
                 "command": "npmScripts.executeCommand",
                 "title": "Run Script"
             }
-        ]
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "NPM-Scripts configuration",
+            "properties": {
+                "npm-scripts.showStartNotification": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show a notification when a script is run."
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,16 +3,17 @@ import { Terminal } from 'vscode';
 import { ScriptNodeProvider } from './npmScripts'
 
 export function activate(context: vscode.ExtensionContext) {
-	const terminalMap = new Map<string, Terminal>();
-
+  const terminalMap = new Map<string, Terminal>();
+  
 	vscode.window.registerTreeDataProvider('npmScripts', new ScriptNodeProvider(vscode.workspace.rootPath));
 	vscode.window.onDidCloseTerminal(term => terminalMap.delete(term.name));
-
+  
 	vscode.commands.registerCommand('npmScripts.executeCommand', task => {
-		const packageManager = vscode.workspace.getConfiguration('npm').get('packageManager') || 'npm';
+    const packageManager = vscode.workspace.getConfiguration('npm').get('packageManager') || 'npm';
 		const command = `${packageManager} run ${task}`;
-
-		vscode.window.showInformationMessage(command);
+    
+    const config = vscode.workspace.getConfiguration('npm-scripts')
+    config['showStartNotification'] && vscode.window.showInformationMessage(command);
 
 		let terminal: Terminal;
 		if (terminalMap.has(task)) {


### PR DESCRIPTION
Closes #2  

> Adds a new workspace configuration option, "npm-scripts.showStartNotification" that will turn off the notification dropdown that appears whenever a script is run by the extension.