### PR TITLE
Adding feature that which show icon in terminal with a color corresponding the npm scripts

### DIFF
--- a/src/executeCommand.ts
+++ b/src/executeCommand.ts
@@ -13,6 +13,7 @@ import * as Message from "./messages";
 import { ConfigOptions, NPM_SCRIPTS } from "./constants";
 import { ITerminalMap } from "./types";
 import { makeTerminalPrettyName } from "./utils";
+import { getTernimalAssets } from "./ternimalAssets";
 
 function resolveAutoPackageManager () {
   const rootPath: string = vscode.workspace.rootPath || ".";
@@ -65,7 +66,13 @@ export function executeCommand(terminalMapping: ITerminalMap) {
     if (terminalMapping.has(name)) {
       terminal = terminalMapping.get(name);
     } else {
-      const terminalOptions: TerminalOptions = { cwd, name };
+      const [icon, color] = getTernimalAssets(name);
+      const terminalOptions: TerminalOptions = {
+        cwd,
+        name,
+        iconPath: new vscode.ThemeIcon(icon),
+        color: new vscode.ThemeColor(color),
+      };
       terminal = vscode.window.createTerminal(terminalOptions);
       terminalMapping.set(name, terminal);
     }

--- a/src/ternimalAssets.ts
+++ b/src/ternimalAssets.ts
@@ -1,0 +1,90 @@
+export const getTernimalAssets = (ScriptMame: string): [string, string] => {
+  var name = ScriptMame.toLowerCase();
+
+  var iconName: string;
+  var iconColor: string;
+
+  if (
+    name.includes("android") ||
+    name.includes("ios") ||
+    name.includes("mobile") ||
+    name.includes("react-native") ||
+    name.includes("expo") ||
+    name.includes("rn") ||
+    name.includes("reactnative") ||
+    name.includes("expo-cli") ||
+    name.includes("application") ||
+    name.includes("app")
+  ) {
+    iconName = "device-mobile";
+    iconColor = "terminal.ansiGreen";
+  } else if (
+    name.includes("electron") ||
+    name.includes("desktop") ||
+    name.includes("electron-app")
+  ) {
+    iconName = "window";
+    iconColor = "terminal.ansiBlue";
+  } else if (
+    name.includes("web") ||
+    name.includes("client") ||
+    name.includes("frontend") ||
+    name.includes("front-end") ||
+    name.includes("react") ||
+    name.includes("vue") ||
+    name.includes("angular") ||
+    name.includes("svelte") ||
+    name.includes("next") ||
+    name.includes("nuxt")
+  ) {
+    iconName = "globe";
+    iconColor = "terminal.ansiCyan";
+  } else if (
+    name.includes("server") ||
+    name.includes("backend") ||
+    name.includes("api") ||
+    name.includes("node") ||
+    name.includes("express")
+  ) {
+    iconName = "server";
+    iconColor = "terminal.ansiMagenta";
+  } else if (
+    name.includes("dev") ||
+    name.includes("development") ||
+    name.includes("dev-server") ||
+    name.includes("development-server")
+  ) {
+    iconName = "tools";
+    iconColor = "terminal.ansiYellow";
+  } else if (
+    name.includes("test") ||
+    name.includes("testing") ||
+    name.includes("jest") ||
+    name.includes("mocha")
+  ) {
+    iconName = "check";
+    iconColor = "terminal.ansiRed";
+  } else if (name.includes("lint")) {
+    iconName = "checklist";
+    iconColor = "terminal.ansiGreen";
+  } else if (
+    name.includes("build") ||
+    name.includes("compile") ||
+    name.includes("bundle") ||
+    name.includes("pack") ||
+    name.includes("package") ||
+    name.includes("webpack") ||
+    name.includes("rollup") ||
+    name.includes("gulp") ||
+    name.includes("grunt")
+  ) {
+    iconName = "package";
+    iconColor = "terminal.ansiBrightCyan";
+  } else {
+    iconName = "rocket";
+    iconColor = "terminal.ansiWhite";
+  }
+
+  return [iconName, iconColor];
+};
+// src/ternimalAsset.ts


### PR DESCRIPTION
This PR introduces a new enhancement that displays icons alongside NPM script names in the terminal. Each icon is color-coded based on the type or purpose of the script, providing quick visual cues and improving overall readability when running npm run.

✅ Key Features:

1. Icons added next to each script for better visual distinction.
2. Color mapping applied based on script type (e.g., build, test, dev, lint, etc.).
3. Helps users quickly identify and differentiate scripts at a glance.
4. Fully compatible with standard terminal environments that support color and emoji.

demo 
<img width="659" height="264" alt="image" src="https://github.com/user-attachments/assets/cd30af2f-bc2b-4a28-b039-026e5a5c605d" />

